### PR TITLE
api provider rewrite & chimu mirror support

### DIFF
--- a/Downloader/Downloader.vcxproj
+++ b/Downloader/Downloader.vcxproj
@@ -169,6 +169,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="src\api\Chimu.h" />
     <ClInclude Include="libraries\cpp-httplib\httplib.h" />
     <ClInclude Include="libraries\curl\curl.h" />
     <ClInclude Include="libraries\curl\curlver.h" />
@@ -204,6 +205,9 @@
     <ClInclude Include="libraries\utility\BlockingContainer.hpp" />
     <ClInclude Include="libraries\utility\Random.hpp" />
     <ClInclude Include="libraries\utility\Sequence.hpp" />
+    <ClInclude Include="src\api\chimu\Map.hpp" />
+    <ClInclude Include="src\api\chimu\Mapset.hpp" />
+    <ClInclude Include="src\api\Provider.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="src\api\Bancho.h" />
     <ClInclude Include="src\api\Sayobot.h" />
@@ -244,6 +248,7 @@
     <ClInclude Include="src\utils\Utils.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\api\Chimu.cpp" />
     <ClCompile Include="libraries\imgui\backends\imgui_impl_dx11.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
@@ -292,6 +297,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="src\api\Provider.cpp" />
     <ClCompile Include="src\api\Bancho.cpp" />
     <ClCompile Include="src\api\Sayobot.cpp" />
     <ClCompile Include="src\config\Field.cpp" />

--- a/Downloader/Downloader.vcxproj.filters
+++ b/Downloader/Downloader.vcxproj.filters
@@ -234,6 +234,18 @@
     <ClInclude Include="src\osu\LinkParser.hpp">
       <Filter>头文件</Filter>
     </ClInclude>
+    <ClInclude Include="src\api\Provider.h">
+      <Filter>头文件</Filter>
+    </ClInclude>
+    <ClInclude Include="src\api\Chimu.h">
+      <Filter>头文件</Filter>
+    </ClInclude>
+    <ClInclude Include="src\api\chimu\Mapset.hpp">
+      <Filter>头文件</Filter>
+    </ClInclude>
+    <ClInclude Include="src\api\chimu\Map.hpp">
+      <Filter>头文件</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\dllmain.cpp">
@@ -333,6 +345,12 @@
       <Filter>源文件</Filter>
     </ClCompile>
     <ClCompile Include="src\features\Settings.cpp">
+      <Filter>源文件</Filter>
+    </ClCompile>
+    <ClCompile Include="src\api\Provider.cpp">
+      <Filter>源文件</Filter>
+    </ClCompile>
+    <ClCompile Include="src\api\Chimu.cpp">
       <Filter>源文件</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Downloader/src/api/Bancho.cpp
+++ b/Downloader/src/api/Bancho.cpp
@@ -6,7 +6,9 @@
 #include "utils/Utils.h"
 #include "utils/gui_utils.h"
 
-std::optional<osu::Beatmap> api::bancho::SearchBeatmap(features::downloader::BeatmapInfo &info) {
+api::Bancho::Bancho() : Provider("Bancho", "https://github.com/ppy/osu-api/wiki", features::downloader::DownloadMirror::OsuOfficial) {}
+
+std::optional<osu::Beatmap> api::Bancho::SearchBeatmap(const features::downloader::BeatmapInfo &info) const {
     auto &dl = features::Downloader::GetInstance();
 
     auto un = dl.f_OsuAccount->username();
@@ -49,11 +51,11 @@ std::optional<osu::Beatmap> api::bancho::SearchBeatmap(features::downloader::Bea
         try {
             auto bm = osu::Beatmap{};
             size_t i = 0;
-            l[i++]; // serverFilename 
+            l[i++]; // serverFilename
             bm.artist = l[i++];
             bm.title = l[i++];
             bm.author = l[i++];
-            l[i++]; // status 
+            l[i++]; // status
             /*
             "1" => SubmissionStatus.Ranked,
             "2" => SubmissionStatus.Approved,
@@ -87,7 +89,7 @@ std::optional<osu::Beatmap> api::bancho::SearchBeatmap(features::downloader::Bea
     return {};
 }
 
-bool api::bancho::DownloadBeatmap(osu::Beatmap &bm) {
+bool api::Bancho::DownloadBeatmap(const osu::Beatmap &bm) const {
     auto &dl = features::Downloader::GetInstance();
 
     auto un = dl.f_OsuAccount->username();

--- a/Downloader/src/api/Chimu.cpp
+++ b/Downloader/src/api/Chimu.cpp
@@ -1,0 +1,77 @@
+#include "pch.h"
+#include "Chimu.h"
+#include "network/HttpRequest.h"
+#include "utils/Utils.h"
+#include "api/chimu/Mapset.hpp"
+#include "api/chimu/Map.hpp"
+
+int32_t api::Chimu::_convertToSetId(const features::downloader::BeatmapInfo &info) const {
+    if (info.type == features::downloader::BeatmapType::Sid) {
+        return info.id;
+    }
+
+    const auto s = std::format("https://api.chimu.moe/v1/map/{0}", info.id);
+
+    std::string response;
+    int32_t resCode;
+    if (const CURLcode code = net::curl_get(s.c_str(), response, &resCode); code != CURLE_OK || resCode != 200) {
+        LOGW("Chimu search failed: code=%d %s", resCode, response.c_str());
+        return -1;
+    }
+
+    const auto j = nlohmann::json::parse(response);
+    api::chumi::ChumiMap map;
+    api::chumi::from_json(j, map);
+    if (map.error_message.has_value()) {
+        LOGW("Chimu search failed: code=%d %s", resCode, map.error_message.value().c_str());
+        return -1;
+    }
+
+    return static_cast<int32_t>(map.parent_set_id.value());
+}
+
+api::Chimu::Chimu() : Provider("Chimu", "https://chimu.moe/docs", features::downloader::DownloadMirror::Chimu) {}
+
+std::optional<osu::Beatmap> api::Chimu::SearchBeatmap(const features::downloader::BeatmapInfo &info) const {
+    int32_t id = _convertToSetId(info);
+    if (id == -1) return {};
+
+    const auto s = std::format("https://api.chimu.moe/v1/set/{0}", id);
+
+	std::string response;
+    int32_t resCode;
+    if (const CURLcode code = net::curl_get(s.c_str(), response, &resCode); code != CURLE_OK || resCode != 200) {
+        LOGW("Chimu search failed: code=%d %s", resCode, response.c_str());
+        return {};
+    }
+
+    const auto j = nlohmann::json::parse(response);
+    api::chumi::ChumiMapset mapset;
+    api::chumi::from_json(j, mapset);
+
+    if (mapset.error_code.has_value() || mapset.error_message.has_value()) {
+        LOGW("Chimu search failed: code=%s %s", mapset.error_code.value().c_str(), mapset.error_message.value().c_str());
+        return {};
+    }
+
+	return mapset.to_beatmap();
+}
+
+bool api::Chimu::DownloadBeatmap(const osu::Beatmap &bm) const {
+    auto &dl = features::Downloader::GetInstance();
+
+    const auto s = std::format("https://api.chimu.moe/v1/download/{0}", bm.sid);
+
+    auto path = utils::GetCurrentDirPath() / L"downloads" / (std::to_string(bm.sid) + ".osz");
+    auto *tsk = features::DownloadQueue::GetInstance().getTask(bm);
+
+    int resCode = -1;
+    if (const auto code = net::curl_download(s.c_str(), path, tsk, &resCode); code == CURLE_OK && resCode == 200) {
+        LOGI("Success download beatmapsets: %d", bm.sid);
+        return true;
+    } else {
+        LOGW("Sayo download failed: CURL_CODE=%d, RESPONSE_CODE=%d", code, resCode);
+    }
+
+    return false;
+}

--- a/Downloader/src/api/Chimu.h
+++ b/Downloader/src/api/Chimu.h
@@ -1,15 +1,15 @@
-﻿#pragma once
-#include "features/Downloader.h"
-#include "osu/Beatmap.h"
+#pragma once
 #include "Provider.h"
 
 namespace api {
-class Bancho : public Provider {
+class Chimu : public Provider {
+    int32_t _convertToSetId(const features::downloader::BeatmapInfo &info) const;
+
 public:
-    Bancho();
+    Chimu();
 
     // Inherited via Provider
     std::optional<osu::Beatmap> SearchBeatmap(const features::downloader::BeatmapInfo &) const override;
     bool DownloadBeatmap(const osu::Beatmap &) const override;
 };
-}
+}; // namespace api

--- a/Downloader/src/api/Provider.cpp
+++ b/Downloader/src/api/Provider.cpp
@@ -1,0 +1,34 @@
+#include "pch.h"
+#include "Provider.h"
+#include "Provider.h"
+
+namespace api {
+
+Provider::Provider(std::string name, std::string doc, features::downloader::DownloadMirror mirror) : _name(name), _doc(doc), _enum(mirror) {}
+
+std::string Provider::GetDoc() const { return _doc; }
+std::string Provider::GetName() const { return _name; }
+
+features::downloader::DownloadMirror Provider::GetEnum() const { return _enum; }
+
+Provider const *Provider::GetRegisteredByName(std::string name) {
+    auto vec = Provider::GetRegistered();
+    return *std::find_if(vec.begin(), vec.end(), [&name](auto p) { return p->GetName() == name; });
+}
+
+Provider const *Provider::GetRegisteredByEnum(features::downloader::DownloadMirror mirror) {
+    auto vec = Provider::GetRegistered();
+    return *std::find_if(vec.begin(), vec.end(), [&mirror](auto p) { return p->GetEnum() == mirror; });
+}
+
+std::vector<const Provider *> Provider::_providers;
+
+void Provider::Register(const Provider *provider) { _providers.push_back(provider); }
+
+void Provider::UnRegisterAll() {
+    for (auto it : Provider::_providers) {
+        delete it;
+    }
+}
+
+}; // namespace api

--- a/Downloader/src/api/Provider.h
+++ b/Downloader/src/api/Provider.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "features/Downloader.h"
+
+namespace api {
+
+class Provider {
+private:
+    static std::vector<const Provider *> _providers;
+
+    std::string _name, _doc;
+    features::downloader::DownloadMirror _enum;
+
+public:
+    Provider(std::string, std::string, features::downloader::DownloadMirror);
+
+    std::string GetDoc() const;
+    std::string GetName() const;
+
+    features::downloader::DownloadMirror GetEnum() const;
+
+    virtual std::optional<osu::Beatmap> SearchBeatmap(const features::downloader::BeatmapInfo &) const = 0;
+    virtual bool DownloadBeatmap(const osu::Beatmap &) const = 0;
+
+    static const std::vector<const Provider *> &GetRegistered() { return Provider::_providers; }
+    static Provider const *GetRegisteredByName(std::string);
+    static Provider const *GetRegisteredByEnum(features::downloader::DownloadMirror);
+    static void Register(const Provider *provider);
+
+    static void UnRegisterAll();
+};
+
+}; // namespace api

--- a/Downloader/src/api/Sayobot.cpp
+++ b/Downloader/src/api/Sayobot.cpp
@@ -4,17 +4,18 @@
 #include "network/HttpRequest.h"
 #include "utils/Utils.h"
 
-void api::sayobot::BidData::to_json(nlohmann::json &j) const {
+namespace api::sayobot {
+void BidData::to_json(nlohmann::json &j) const {
     j.at("bid") = bid;
     j.at("mode") = mode;
 }
 
-void api::sayobot::BidData::from_json(const nlohmann::json &j) {
+void BidData::from_json(const nlohmann::json &j) {
     j.at("bid").get_to(bid);
     j.at("mode").get_to(mode);
 }
 
-void api::sayobot::SayoBeatmapDataV2::to_json(nlohmann::json &j) const {
+void SayoBeatmapDataV2::to_json(nlohmann::json &j) const {
     j.at("approved") = approved;
     j.at("artist") = artist;
     j.at("artistU") = artistU;
@@ -27,7 +28,7 @@ void api::sayobot::SayoBeatmapDataV2::to_json(nlohmann::json &j) const {
     j.at("bid_data") = bidData;
 }
 
-void api::sayobot::SayoBeatmapDataV2::from_json(const nlohmann::json &j) {
+void SayoBeatmapDataV2::from_json(const nlohmann::json &j) {
     j.at("approved").get_to(approved);
     j.at("artist").get_to(artist);
     j.at("artistU").get_to(artistU);
@@ -40,7 +41,7 @@ void api::sayobot::SayoBeatmapDataV2::from_json(const nlohmann::json &j) {
     j.at("bid_data").get_to(bidData);
 }
 
-osu::Beatmap api::sayobot::SayoBeatmapDataV2::to_beatmap() const {
+osu::Beatmap SayoBeatmapDataV2::to_beatmap() const {
     std::vector<int32_t> bids;
     bids.reserve(bidData.size());
     for (auto &bd : bidData) {
@@ -49,19 +50,31 @@ osu::Beatmap api::sayobot::SayoBeatmapDataV2::to_beatmap() const {
     return {title, artist, creator, bids, sid, video != 0};
 }
 
-std::optional<api::sayobot::SayoResult<api::sayobot::SayoBeatmapDataV2>> api::sayobot::SearchBeatmapV2(
-    const features::downloader::BeatmapInfo &info) {
+};
+
+void nlohmann::adl_serializer<api::sayobot::BidData>::to_json(nlohmann::json &j, const api::sayobot::BidData &data) { data.to_json(j); }
+
+void nlohmann::adl_serializer<api::sayobot::BidData>::from_json(const nlohmann::json &j, api::sayobot::BidData &data) { data.from_json(j); }
+
+api::Sayobot::Sayobot() :
+    Provider("Sayobot", "https://www.showdoc.com.cn/SoulDee?page_id=3969517351482508", features::downloader::DownloadMirror::Sayobot) {}
+
+std::optional<osu::Beatmap> api::Sayobot::SearchBeatmap(const features::downloader::BeatmapInfo &info) const {
     const auto s = std::format("https://api.sayobot.cn/v2/beatmapinfo?K={0}&T={1}", info.id, (uint8_t)info.type);
     int resCode = -1;
     std::string response;
     if (const CURLcode code = net::curl_get(s.c_str(), response, &resCode); code == CURLE_OK && resCode == 200) {
         // LOGD("Sayo search response: %s", response.c_str());
         const auto j = nlohmann::json::parse(response);
-        SayoResult<SayoBeatmapDataV2> data;
+        api::sayobot::SayoResult<api::sayobot::SayoBeatmapDataV2> data;
         data.from_json(j);
 
         if (data.status == 0) {
-            return data;
+            if (data.data.has_value()) {
+                return std::optional(data.data.value().to_beatmap());
+            } else {
+                return {};
+            }
         }
 
         LOGW("Sayo search failed: code=%d", data.status);
@@ -72,7 +85,7 @@ std::optional<api::sayobot::SayoResult<api::sayobot::SayoBeatmapDataV2>> api::sa
     return {};
 }
 
-bool api::sayobot::DownloadBeatmap(osu::Beatmap &bm) {
+bool api::Sayobot::DownloadBeatmap(const osu::Beatmap &bm) const {
     auto &dl = features::Downloader::GetInstance();
 
     const auto s = std::format("https://txy1.sayobot.cn/beatmaps/download/{0}/{1}?server=auto",
@@ -90,12 +103,4 @@ bool api::sayobot::DownloadBeatmap(osu::Beatmap &bm) {
     }
 
     return false;
-}
-
-void nlohmann::adl_serializer<api::sayobot::BidData, void>::to_json(json &j, const api::sayobot::BidData &data) {
-    data.to_json(j);
-}
-
-void nlohmann::adl_serializer<api::sayobot::BidData, void>::from_json(const json &j, api::sayobot::BidData &data) {
-    data.from_json(j);
 }

--- a/Downloader/src/api/Sayobot.h
+++ b/Downloader/src/api/Sayobot.h
@@ -4,6 +4,18 @@
 #include <json.hpp>
 #include "misc/ISerializable.h"
 #include "features/Downloader.h"
+#include "Provider.h"
+
+namespace api {
+class Sayobot : public Provider {
+public:
+    Sayobot();
+
+    // Inherited via Provider
+    virtual std::optional<osu::Beatmap> SearchBeatmap(const features::downloader::BeatmapInfo &) const override;
+    virtual bool DownloadBeatmap(const osu::Beatmap &) const override;
+};
+};
 
 namespace api::sayobot {
 struct BidData : ISerializable {
@@ -60,9 +72,6 @@ void SayoResult<T, E0>::from_json(const nlohmann::json &j) {
     }
 }
 
-std::optional<SayoResult<SayoBeatmapDataV2>> SearchBeatmapV2(const features::downloader::BeatmapInfo &info);
-
-bool DownloadBeatmap(osu::Beatmap &bm);
 }
 
 template <>

--- a/Downloader/src/api/chimu/Map.hpp
+++ b/Downloader/src/api/chimu/Map.hpp
@@ -1,0 +1,176 @@
+#pragma once
+//  To parse this JSON data, first install
+//
+//      json.hpp  https://github.com/nlohmann/json
+//
+//  Then include this file, and then do
+//
+//     ChumiMap data = nlohmann::json::parse(jsonString);
+
+#pragma once
+
+#include <optional>
+#include "json.hpp"
+
+#ifndef NLOHMANN_OPT_HELPER
+#define NLOHMANN_OPT_HELPER
+namespace nlohmann {
+template <typename T>
+struct adl_serializer<std::shared_ptr<T>> {
+    static void to_json(json &j, const std::shared_ptr<T> &opt) {
+        if (!opt)
+            j = nullptr;
+        else
+            j = *opt;
+    }
+
+    static std::shared_ptr<T> from_json(const json &j) {
+        if (j.is_null())
+            return std::make_shared<T>();
+        else
+            return std::make_shared<T>(j.get<T>());
+    }
+};
+template <typename T>
+struct adl_serializer<std::optional<T>> {
+    static void to_json(json &j, const std::optional<T> &opt) {
+        if (!opt)
+            j = nullptr;
+        else
+            j = *opt;
+    }
+
+    static std::optional<T> from_json(const json &j) {
+        if (j.is_null())
+            return std::make_optional<T>();
+        else
+            return std::make_optional<T>(j.get<T>());
+    }
+};
+} // namespace nlohmann
+#endif
+
+namespace api {
+namespace chumi {
+using nlohmann::json;
+
+#ifndef NLOHMANN_UNTYPED_api_chumi_HELPER
+#define NLOHMANN_UNTYPED_api_chumi_HELPER
+inline json get_untyped(const json &j, const char *property) {
+    if (j.find(property) != j.end()) {
+        return j.at(property).get<json>();
+    }
+    return json();
+}
+
+inline json get_untyped(const json &j, std::string property) { return get_untyped(j, property.data()); }
+#endif
+
+#ifndef NLOHMANN_OPTIONAL_api_chumi_HELPER
+#define NLOHMANN_OPTIONAL_api_chumi_HELPER
+template <typename T>
+inline std::shared_ptr<T> get_heap_optional(const json &j, const char *property) {
+    auto it = j.find(property);
+    if (it != j.end() && !it->is_null()) {
+        return j.at(property).get<std::shared_ptr<T>>();
+    }
+    return std::shared_ptr<T>();
+}
+
+template <typename T>
+inline std::shared_ptr<T> get_heap_optional(const json &j, std::string property) {
+    return get_heap_optional<T>(j, property.data());
+}
+template <typename T>
+inline std::optional<T> get_stack_optional(const json &j, const char *property) {
+    auto it = j.find(property);
+    if (it != j.end() && !it->is_null()) {
+        return j.at(property).get<std::optional<T>>();
+    }
+    return std::optional<T>();
+}
+
+template <typename T>
+inline std::optional<T> get_stack_optional(const json &j, std::string property) {
+    return get_stack_optional<T>(j, property.data());
+}
+#endif
+
+struct ChumiMap {
+    std::optional<int64_t> beatmap_id;
+    std::optional<int64_t> parent_set_id;
+    std::optional<std::string> diff_name;
+    std::optional<std::string> file_md5;
+    std::optional<int64_t> mode;
+    std::optional<int64_t> bpm;
+    std::optional<int64_t> ar;
+    std::optional<int64_t> od;
+    std::optional<int64_t> cs;
+    std::optional<int64_t> hp;
+    std::optional<int64_t> total_length;
+    std::optional<int64_t> hit_length;
+    std::optional<int64_t> playcount;
+    std::optional<int64_t> passcount;
+    std::optional<int64_t> max_combo;
+    std::optional<double> difficulty_rating;
+    std::optional<std::string> osu_file;
+    std::optional<std::string> download_path;
+    std::optional<std::string> error_message;
+    std::optional<std::string> error_code;
+};
+} // namespace chumi
+} // namespace api
+
+namespace api {
+namespace chumi {
+void from_json(const json &j, ChumiMap &x);
+void to_json(json &j, const ChumiMap &x);
+
+inline void from_json(const json &j, ChumiMap &x) {
+    x.beatmap_id = get_stack_optional<int64_t>(j, "BeatmapId");
+    x.parent_set_id = get_stack_optional<int64_t>(j, "ParentSetId");
+    x.diff_name = get_stack_optional<std::string>(j, "DiffName");
+    x.file_md5 = get_stack_optional<std::string>(j, "FileMD5");
+    x.mode = get_stack_optional<int64_t>(j, "Mode");
+    x.bpm = get_stack_optional<int64_t>(j, "BPM");
+    x.ar = get_stack_optional<int64_t>(j, "AR");
+    x.od = get_stack_optional<int64_t>(j, "OD");
+    x.cs = get_stack_optional<int64_t>(j, "CS");
+    x.hp = get_stack_optional<int64_t>(j, "HP");
+    x.total_length = get_stack_optional<int64_t>(j, "TotalLength");
+    x.hit_length = get_stack_optional<int64_t>(j, "HitLength");
+    x.playcount = get_stack_optional<int64_t>(j, "Playcount");
+    x.passcount = get_stack_optional<int64_t>(j, "Passcount");
+    x.max_combo = get_stack_optional<int64_t>(j, "MaxCombo");
+    x.difficulty_rating = get_stack_optional<double>(j, "DifficultyRating");
+    x.osu_file = get_stack_optional<std::string>(j, "OsuFile");
+    x.download_path = get_stack_optional<std::string>(j, "DownloadPath");
+    x.error_message = get_stack_optional<std::string>(j, "error_message");
+    x.error_code = get_stack_optional<std::string>(j, "error_code");
+}
+
+inline void to_json(json &j, const ChumiMap &x) {
+    j = json::object();
+    j["BeatmapId"] = x.beatmap_id;
+    j["ParentSetId"] = x.parent_set_id;
+    j["DiffName"] = x.diff_name;
+    j["FileMD5"] = x.file_md5;
+    j["Mode"] = x.mode;
+    j["BPM"] = x.bpm;
+    j["AR"] = x.ar;
+    j["OD"] = x.od;
+    j["CS"] = x.cs;
+    j["HP"] = x.hp;
+    j["TotalLength"] = x.total_length;
+    j["HitLength"] = x.hit_length;
+    j["Playcount"] = x.playcount;
+    j["Passcount"] = x.passcount;
+    j["MaxCombo"] = x.max_combo;
+    j["DifficultyRating"] = x.difficulty_rating;
+    j["OsuFile"] = x.osu_file;
+    j["DownloadPath"] = x.download_path;
+    j["error_message"] = x.error_message;
+    j["error_code"] = x.error_code;
+}
+} // namespace chumi
+} // namespace api

--- a/Downloader/src/api/chimu/Mapset.hpp
+++ b/Downloader/src/api/chimu/Mapset.hpp
@@ -1,0 +1,249 @@
+#pragma once
+//  To parse this JSON data, first install
+//
+//      json.hpp  https://github.com/nlohmann/json
+//
+//  Then include this file, and then do
+//
+//     ChumiMapset data = nlohmann::json::parse(jsonString);
+
+#pragma once
+
+#include <optional>
+#include "json.hpp"
+
+#ifndef NLOHMANN_OPT_HELPER
+#define NLOHMANN_OPT_HELPER
+namespace nlohmann {
+template <typename T>
+struct adl_serializer<std::shared_ptr<T>> {
+    static void to_json(json &j, const std::shared_ptr<T> &opt) {
+        if (!opt)
+            j = nullptr;
+        else
+            j = *opt;
+    }
+
+    static std::shared_ptr<T> from_json(const json &j) {
+        if (j.is_null())
+            return std::make_shared<T>();
+        else
+            return std::make_shared<T>(j.get<T>());
+    }
+};
+template <typename T>
+struct adl_serializer<std::optional<T>> {
+    static void to_json(json &j, const std::optional<T> &opt) {
+        if (!opt)
+            j = nullptr;
+        else
+            j = *opt;
+    }
+
+    static std::optional<T> from_json(const json &j) {
+        if (j.is_null())
+            return std::make_optional<T>();
+        else
+            return std::make_optional<T>(j.get<T>());
+    }
+};
+} // namespace nlohmann
+#endif
+
+namespace api {
+namespace chumi {
+using nlohmann::json;
+
+#ifndef NLOHMANN_UNTYPED_api_chumi_HELPER
+#define NLOHMANN_UNTYPED_api_chumi_HELPER
+inline json get_untyped(const json &j, const char *property) {
+    if (j.find(property) != j.end()) {
+        return j.at(property).get<json>();
+    }
+    return json();
+}
+
+inline json get_untyped(const json &j, std::string property) { return get_untyped(j, property.data()); }
+#endif
+
+#ifndef NLOHMANN_OPTIONAL_api_chumi_HELPER
+#define NLOHMANN_OPTIONAL_api_chumi_HELPER
+template <typename T>
+inline std::shared_ptr<T> get_heap_optional(const json &j, const char *property) {
+    auto it = j.find(property);
+    if (it != j.end() && !it->is_null()) {
+        return j.at(property).get<std::shared_ptr<T>>();
+    }
+    return std::shared_ptr<T>();
+}
+
+template <typename T>
+inline std::shared_ptr<T> get_heap_optional(const json &j, std::string property) {
+    return get_heap_optional<T>(j, property.data());
+}
+template <typename T>
+inline std::optional<T> get_stack_optional(const json &j, const char *property) {
+    auto it = j.find(property);
+    if (it != j.end() && !it->is_null()) {
+        return j.at(property).get<std::optional<T>>();
+    }
+    return std::optional<T>();
+}
+
+template <typename T>
+inline std::optional<T> get_stack_optional(const json &j, std::string property) {
+    return get_stack_optional<T>(j, property.data());
+}
+#endif
+
+struct ChildrenBeatmap {
+    std::optional<int64_t> beatmap_id;
+    std::optional<int64_t> parent_set_id;
+    std::optional<std::string> diff_name;
+    std::optional<std::string> file_md5;
+    std::optional<int64_t> mode;
+    std::optional<double> bpm;
+    std::optional<int64_t> ar;
+    std::optional<int64_t> od;
+    std::optional<int64_t> cs;
+    std::optional<int64_t> hp;
+    std::optional<int64_t> total_length;
+    std::optional<int64_t> hit_length;
+    std::optional<int64_t> playcount;
+    std::optional<int64_t> passcount;
+    std::optional<int64_t> max_combo;
+    std::optional<double> difficulty_rating;
+    std::optional<std::string> osu_file;
+    std::optional<std::string> download_path;
+};
+
+struct ChumiMapset {
+    std::optional<int64_t> set_id;
+    std::optional<std::vector<ChildrenBeatmap>> children_beatmaps;
+    std::optional<int64_t> ranked_status;
+    std::optional<std::string> approved_date;
+    std::optional<std::string> last_update;
+    std::optional<std::string> last_checked;
+    std::optional<std::string> artist;
+    std::optional<std::string> title;
+    std::optional<std::string> creator;
+    std::optional<std::string> source;
+    std::optional<std::string> tags;
+    std::optional<bool> has_video;
+    std::optional<int64_t> genre;
+    std::optional<int64_t> language;
+    std::optional<int64_t> favourites;
+    std::optional<bool> disabled;
+    std::optional<std::string> error_message;
+    std::optional<std::string> error_code;
+
+    osu::Beatmap to_beatmap() const;
+};
+
+osu::Beatmap ChumiMapset::to_beatmap() const {
+    std::vector<int> ids;
+    ids.reserve(children_beatmaps.value().size());
+    for (auto it : children_beatmaps.value()) {
+        ids.push_back(static_cast<int>(it.beatmap_id.value()));
+    }
+    return {title.value(), artist.value(), creator.value(), ids, static_cast<int>(set_id.value()), has_video.value() != 0};
+}
+
+} // namespace chumi
+} // namespace api
+
+namespace api {
+namespace chumi {
+void from_json(const json &j, ChildrenBeatmap &x);
+void to_json(json &j, const ChildrenBeatmap &x);
+
+void from_json(const json &j, ChumiMapset &x);
+void to_json(json &j, const ChumiMapset &x);
+
+inline void from_json(const json &j, ChildrenBeatmap &x) {
+    x.beatmap_id = get_stack_optional<int64_t>(j, "BeatmapId");
+    x.parent_set_id = get_stack_optional<int64_t>(j, "ParentSetId");
+    x.diff_name = get_stack_optional<std::string>(j, "DiffName");
+    x.file_md5 = get_stack_optional<std::string>(j, "FileMD5");
+    x.mode = get_stack_optional<int64_t>(j, "Mode");
+    x.bpm = get_stack_optional<double>(j, "BPM");
+    x.ar = get_stack_optional<int64_t>(j, "AR");
+    x.od = get_stack_optional<int64_t>(j, "OD");
+    x.cs = get_stack_optional<int64_t>(j, "CS");
+    x.hp = get_stack_optional<int64_t>(j, "HP");
+    x.total_length = get_stack_optional<int64_t>(j, "TotalLength");
+    x.hit_length = get_stack_optional<int64_t>(j, "HitLength");
+    x.playcount = get_stack_optional<int64_t>(j, "Playcount");
+    x.passcount = get_stack_optional<int64_t>(j, "Passcount");
+    x.max_combo = get_stack_optional<int64_t>(j, "MaxCombo");
+    x.difficulty_rating = get_stack_optional<double>(j, "DifficultyRating");
+    x.osu_file = get_stack_optional<std::string>(j, "OsuFile");
+    x.download_path = get_stack_optional<std::string>(j, "DownloadPath");
+}
+
+inline void to_json(json &j, const ChildrenBeatmap &x) {
+    j = json::object();
+    j["BeatmapId"] = x.beatmap_id;
+    j["ParentSetId"] = x.parent_set_id;
+    j["DiffName"] = x.diff_name;
+    j["FileMD5"] = x.file_md5;
+    j["Mode"] = x.mode;
+    j["BPM"] = x.bpm;
+    j["AR"] = x.ar;
+    j["OD"] = x.od;
+    j["CS"] = x.cs;
+    j["HP"] = x.hp;
+    j["TotalLength"] = x.total_length;
+    j["HitLength"] = x.hit_length;
+    j["Playcount"] = x.playcount;
+    j["Passcount"] = x.passcount;
+    j["MaxCombo"] = x.max_combo;
+    j["DifficultyRating"] = x.difficulty_rating;
+    j["OsuFile"] = x.osu_file;
+    j["DownloadPath"] = x.download_path;
+}
+
+inline void from_json(const json &j, ChumiMapset &x) {
+    x.set_id = get_stack_optional<int64_t>(j, "SetId");
+    x.children_beatmaps = get_stack_optional<std::vector<ChildrenBeatmap>>(j, "ChildrenBeatmaps");
+    x.ranked_status = get_stack_optional<int64_t>(j, "RankedStatus");
+    x.approved_date = get_stack_optional<std::string>(j, "ApprovedDate");
+    x.last_update = get_stack_optional<std::string>(j, "LastUpdate");
+    x.last_checked = get_stack_optional<std::string>(j, "LastChecked");
+    x.artist = get_stack_optional<std::string>(j, "Artist");
+    x.title = get_stack_optional<std::string>(j, "Title");
+    x.creator = get_stack_optional<std::string>(j, "Creator");
+    x.source = get_stack_optional<std::string>(j, "Source");
+    x.tags = get_stack_optional<std::string>(j, "Tags");
+    x.has_video = get_stack_optional<bool>(j, "HasVideo");
+    x.genre = get_stack_optional<int64_t>(j, "Genre");
+    x.language = get_stack_optional<int64_t>(j, "Language");
+    x.favourites = get_stack_optional<int64_t>(j, "Favourites");
+    x.disabled = get_stack_optional<bool>(j, "Disabled");
+    x.error_message = get_stack_optional<std::string>(j, "error_message");
+    x.error_code = get_stack_optional<std::string>(j, "error_code");
+}
+
+inline void to_json(json &j, const ChumiMapset &x) {
+    j = json::object();
+    j["SetId"] = x.set_id;
+    j["ChildrenBeatmaps"] = x.children_beatmaps;
+    j["RankedStatus"] = x.ranked_status;
+    j["ApprovedDate"] = x.approved_date;
+    j["LastUpdate"] = x.last_update;
+    j["LastChecked"] = x.last_checked;
+    j["Artist"] = x.artist;
+    j["Title"] = x.title;
+    j["Creator"] = x.creator;
+    j["Source"] = x.source;
+    j["Tags"] = x.tags;
+    j["HasVideo"] = x.has_video;
+    j["Genre"] = x.genre;
+    j["Language"] = x.language;
+    j["Favourites"] = x.favourites;
+    j["Disabled"] = x.disabled;
+    j["error_message"] = x.error_message;
+    j["error_code"] = x.error_code;
+}
+} // namespace chumi
+} // namespace api

--- a/Downloader/src/dllmain.cpp
+++ b/Downloader/src/dllmain.cpp
@@ -19,6 +19,7 @@ BOOL APIENTRY DllMain(HMODULE hModule,
                 UnhookWindowsHookEx(renderer::g_msgHook);
             }
             config::Save();
+            api::Provider::UnRegisterAll();
             break;
     }
     return TRUE;

--- a/Downloader/src/features/Downloader.h
+++ b/Downloader/src/features/Downloader.h
@@ -14,7 +14,7 @@ namespace downloader {
 enum class DownloadMirror : uint8_t {
     OsuOfficial = 0,
     Sayobot,
-    // Chimu,
+    Chimu,
 };
 
 enum class BeatmapType : uint8_t {

--- a/Downloader/src/main.hpp
+++ b/Downloader/src/main.hpp
@@ -98,6 +98,10 @@ void Run(HMODULE *phModule) {
 #include "features/DownloadQueue.h"
 #include "features/MultiDownload.h"
 #include "features/CustomHotkey.h"
+#include "api/Provider.h"
+#include "api/Bancho.h"
+#include "api/Sayobot.h"
+#include "api/Chimu.h"
 
 #define INIT_FEAT(NAME) ui::main::AddFeature(&features::NAME::GetInstance())
 
@@ -109,4 +113,8 @@ inline void InitFeatures() {
     INIT_FEAT(HandleLinkHook);
     INIT_FEAT(MultiDownload);
     INIT_FEAT(DownloadQueue);
+
+    api::Provider::Register(new api::Bancho());
+    api::Provider::Register(new api::Sayobot());
+    api::Provider::Register(new api::Chimu());
 }


### PR DESCRIPTION
Tried to make api more easily expandable through providers base class

Currently only 3 steps needed to implement new provider.
1. Register provider through Provider::Register()
2. Add new enum member to [DownloadMirror](https://github.com/EnergoStalin/BeatmapDownloader/blob/7d6359e17f3ff9306fc28220e9c09c3e97a28c89/Downloader/src/features/Downloader.h#L14)
3. Populate [ui](https://github.com/EnergoStalin/BeatmapDownloader/blob/7d6359e17f3ff9306fc28220e9c09c3e97a28c89/Downloader/src/features/Downloader.cpp#L161) with new provider manually

There's a lot of improvement's can be made but i'm feeling lazy to do more...